### PR TITLE
fix: add grep action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ function filterLine(callback: (lineContent: string, lineNumber: number) => boole
 filterLine((lineContent, lineNumber) => lineNumber % 2 === 0);
 ```
 
+### grep
+
+Filters lines matching a pattern, similar to the Unix grep command. Supports both string and regex patterns.
+
+```js
+function grep(pattern: string | RegExp, invert?: boolean): void
+```
+
+```js
+// Keep lines containing 'error'
+grep('error');
+
+// Keep lines starting with numbers
+grep(/^\d+/);
+
+// Keep lines that do NOT contain 'debug' (inverted match)
+grep('debug', true);
+
+// Case-insensitive search
+grep(/error/i);
+```
+
 ### transformLine
 
 Iterates over every line of the input and puts the result of the callback into the output in its place.

--- a/src/monaco-extra-libs/action-functions.d.ts
+++ b/src/monaco-extra-libs/action-functions.d.ts
@@ -18,6 +18,14 @@ declare function CallbackFilterLine(
 ): boolean;
 
 /**
+ * Filters lines matching a pattern (similar to Unix grep command)
+ * @param {string | RegExp} pattern The string or regex pattern to search for
+ * @param {boolean} [invert=false] If true, returns lines that do NOT match the pattern
+ * @returns void
+ */
+declare function grep(pattern: string | RegExp, invert?: boolean): void;
+
+/**
  * Parses the output of the previous action to a json object and gives it to the provided callback
  * @param {CallbackJsonParse} callback The provided callback will be called with the json object parsed from the output of the previous action
  * @param {number} [indentation=2] The indentation that is used to stringify the json object
@@ -113,6 +121,7 @@ declare function unique(): void;
 
 declare interface TextwandlerFunctions {
     filterLine: typeof filterLine;
+    grep: typeof grep;
     jsonParse: typeof jsonParse;
     jsonStringify: typeof jsonStringify;
     reduce: typeof reduce;

--- a/src/textwandler/wandler-pipeline/actions/action-grep.ts
+++ b/src/textwandler/wandler-pipeline/actions/action-grep.ts
@@ -1,0 +1,31 @@
+import { Action, ActionResult } from './action';
+
+export class ActionGrep extends Action {
+    public readonly name: string = 'Grep';
+
+    constructor(
+        private readonly pattern: string | RegExp,
+        private readonly invert: boolean = false
+    ) {
+        super();
+    }
+
+    run(input: ActionResult): ActionResult {
+        const lines = input.text.split(/\n/);
+        
+        let regex: RegExp;
+        if (typeof this.pattern === 'string') {
+            regex = new RegExp(this.pattern);
+        } else {
+            regex = this.pattern;
+        }
+
+        const filteredLines = lines.filter(line => {
+            const matches = regex.test(line);
+            return this.invert ? !matches : matches;
+        });
+
+        input.text = filteredLines.join('\n');
+        return input;
+    }
+}

--- a/src/textwandler/wandler-pipeline/actions/action-grep.ts
+++ b/src/textwandler/wandler-pipeline/actions/action-grep.ts
@@ -12,7 +12,7 @@ export class ActionGrep extends Action {
 
     run(input: ActionResult): ActionResult {
         const lines = input.text.split(/\n/);
-        
+
         let regex: RegExp;
         if (typeof this.pattern === 'string') {
             regex = new RegExp(this.pattern);
@@ -20,7 +20,7 @@ export class ActionGrep extends Action {
             regex = this.pattern;
         }
 
-        const filteredLines = lines.filter(line => {
+        const filteredLines = lines.filter((line) => {
             const matches = regex.test(line);
             return this.invert ? !matches : matches;
         });

--- a/src/textwandler/wandler-pipeline/actions/index.ts
+++ b/src/textwandler/wandler-pipeline/actions/index.ts
@@ -1,5 +1,6 @@
 export { Action } from './action';
 export { ActionFilterLine } from './action-filter-line';
+export { ActionGrep } from './action-grep';
 export { ActionJsonParse } from './action-json-parse';
 export { ActionJsonStringify } from './action-json-stringify';
 export { ActionReduce } from './action-reduce';

--- a/src/textwandler/wandler-pipeline/pipeline.ts
+++ b/src/textwandler/wandler-pipeline/pipeline.ts
@@ -1,6 +1,7 @@
 import { Action, ActionResult } from './actions/action';
 import { ActionTransformLine } from './actions/action-transform-line';
 import { ActionFilterLine } from './actions/action-filter-line';
+import { ActionGrep } from './actions/action-grep';
 import { ActionSetValue } from './actions/action-set-value';
 import { ActionReduce } from './actions/action-reduce';
 import { ActionJsonStringify } from './actions/action-json-stringify';
@@ -81,6 +82,9 @@ export class WandlerPipeline {
                 lineMapper: (line: string, lineNumber: number) => boolean
             ) => {
                 this.addAction(new ActionFilterLine(lineMapper));
+            },
+            grep: (pattern: string | RegExp, invert?: boolean) => {
+                this.addAction(new ActionGrep(pattern, invert));
             },
             jsonParse: (
                 transformJsonFunction: (

--- a/test/e2e/actions.e2e.test.ts
+++ b/test/e2e/actions.e2e.test.ts
@@ -150,17 +150,17 @@ test('Action: grep - string pattern', async ({ page }) => {
     await testEditorContent(
         page,
         `grep('error');`,
-        `info: starting\nerror: failed\nwarn: issue\nerror: timeout`,
-        `error: failed\nerror: timeout`
+        `info:starting\nerror:failed\nwarn:issue\nerror:timeout`,
+        `error:failed\nerror:timeout`
     );
 });
 
 test('Action: grep - regex pattern', async ({ page }) => {
     await testEditorContent(
         page,
-        `grep(/^\\d+/);`,
-        `123 number line\ntext line\n456 another number\nmore text`,
-        `123 number line\n456 another number`
+        `grep(/\\d+$/);`,
+        `lineendingwith123\ntextline\nanotherlinewith456\nmoretext`,
+        `lineendingwith123\nanotherlinewith456`
     );
 });
 
@@ -168,7 +168,7 @@ test('Action: grep - with invert flag', async ({ page }) => {
     await testEditorContent(
         page,
         `grep('error', true);`,
-        `info: starting\nerror: failed\nwarn: issue\nerror: timeout`,
-        `info: starting\nwarn: issue`
+        `info:starting\nerror:failed\nwarn:issue\nerror:timeout`,
+        `info:starting\nwarn:issue`
     );
 });

--- a/test/e2e/actions.e2e.test.ts
+++ b/test/e2e/actions.e2e.test.ts
@@ -91,3 +91,30 @@ test('Action: unique', async ({ page }) => {
         `x\nz\n111\n222`
     );
 });
+
+test('Action: grep - string pattern', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `grep('error');`,
+        `info: starting\nerror: failed\nwarn: issue\nerror: timeout`,
+        `error: failed\nerror: timeout`
+    );
+});
+
+test('Action: grep - regex pattern', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `grep(/^\\d+/);`,
+        `123 number line\ntext line\n456 another number\nmore text`,
+        `123 number line\n456 another number`
+    );
+});
+
+test('Action: grep - with invert flag', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `grep('error', true);`,
+        `info: starting\nerror: failed\nwarn: issue\nerror: timeout`,
+        `info: starting\nwarn: issue`
+    );
+});

--- a/test/textwandler/wandler-pipeline/pipeline.test.ts
+++ b/test/textwandler/wandler-pipeline/pipeline.test.ts
@@ -4,6 +4,7 @@ import {
     ActionReduce,
     ActionSetValue,
     ActionFilterLine,
+    ActionGrep,
     ActionJsonStringify,
     ActionJsonParse,
     WandlerPipeline,
@@ -204,6 +205,39 @@ describe('Test of WandlerPipeline', () => {
           c
           1
           2"
+        `);
+    });
+
+    it('should execute grep action with string pattern', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionGrep('error'));
+
+        const result = pipeline.run('info: starting\nerror: failed\nwarn: issue\nerror: timeout');
+        expect(result).toMatchInlineSnapshot(`
+          "error: failed
+          error: timeout"
+        `);
+    });
+
+    it('should execute grep action with regex pattern', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionGrep(/^\d+/));
+
+        const result = pipeline.run('123 number line\ntext line\n456 another number\nmore text');
+        expect(result).toMatchInlineSnapshot(`
+          "123 number line
+          456 another number"
+        `);
+    });
+
+    it('should execute grep action with invert flag', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionGrep('error', true));
+
+        const result = pipeline.run('info: starting\nerror: failed\nwarn: issue\nerror: timeout');
+        expect(result).toMatchInlineSnapshot(`
+          "info: starting
+          warn: issue"
         `);
     });
 });

--- a/test/textwandler/wandler-pipeline/pipeline.test.ts
+++ b/test/textwandler/wandler-pipeline/pipeline.test.ts
@@ -291,7 +291,9 @@ describe('Test of WandlerPipeline', () => {
         const pipeline = new WandlerPipeline();
         pipeline.addAction(new ActionGrep('error'));
 
-        const result = pipeline.run('info: starting\nerror: failed\nwarn: issue\nerror: timeout');
+        const result = pipeline.run(
+            'info: starting\nerror: failed\nwarn: issue\nerror: timeout'
+        );
         expect(result).toMatchInlineSnapshot(`
           "error: failed
           error: timeout"
@@ -302,7 +304,9 @@ describe('Test of WandlerPipeline', () => {
         const pipeline = new WandlerPipeline();
         pipeline.addAction(new ActionGrep(/^\d+/));
 
-        const result = pipeline.run('123 number line\ntext line\n456 another number\nmore text');
+        const result = pipeline.run(
+            '123 number line\ntext line\n456 another number\nmore text'
+        );
         expect(result).toMatchInlineSnapshot(`
           "123 number line
           456 another number"
@@ -313,7 +317,9 @@ describe('Test of WandlerPipeline', () => {
         const pipeline = new WandlerPipeline();
         pipeline.addAction(new ActionGrep('error', true));
 
-        const result = pipeline.run('info: starting\nerror: failed\nwarn: issue\nerror: timeout');
+        const result = pipeline.run(
+            'info: starting\nerror: failed\nwarn: issue\nerror: timeout'
+        );
         expect(result).toMatchInlineSnapshot(`
           "info: starting
           warn: issue"


### PR DESCRIPTION
Implement grep action for pattern-based line filtering.

- Created ActionGrep class supporting string and RegExp patterns
- Added grep() method to pipeline context with optional invert flag
- Added unit tests and e2e tests for various grep scenarios
- Updated TypeScript definitions and README
- Supports inverted matching and regex patterns