### PR TITLE
fix: add join action

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ function setValue((input: string) => string): void
 setValue(() => 'set the output to this string\nnext line');
 ```
 
+### join
+
+Joins all lines with a specified separator. Useful for converting multi-line text to single line or custom formats.
+
+```js
+function join(separator?: string): void
+```
+
+```js
+// Join lines with comma and space
+join(', ');
+
+// Join lines with pipe separator
+join(' | ');
+
+// Join lines with just space
+join(' ');
+
+// Default behavior (keeps newlines)
+join();
+```
+
 ### jsonParse
 
 Parses the input as a json object or array and allows the manipulation in the callback.

--- a/src/monaco-extra-libs/action-functions.d.ts
+++ b/src/monaco-extra-libs/action-functions.d.ts
@@ -18,6 +18,13 @@ declare function CallbackFilterLine(
 ): boolean;
 
 /**
+ * Joins all lines with a specified separator
+ * @param {string} [separator='\n'] The separator to use between lines
+ * @returns void
+ */
+declare function join(separator?: string): void;
+
+/**
  * Parses the output of the previous action to a json object and gives it to the provided callback
  * @param {CallbackJsonParse} callback The provided callback will be called with the json object parsed from the output of the previous action
  * @param {number} [indentation=2] The indentation that is used to stringify the json object
@@ -113,6 +120,7 @@ declare function unique(): void;
 
 declare interface TextwandlerFunctions {
     filterLine: typeof filterLine;
+    join: typeof join;
     jsonParse: typeof jsonParse;
     jsonStringify: typeof jsonStringify;
     reduce: typeof reduce;

--- a/src/textwandler/wandler-pipeline/actions/action-join.ts
+++ b/src/textwandler/wandler-pipeline/actions/action-join.ts
@@ -1,0 +1,15 @@
+import { Action, ActionResult } from './action';
+
+export class ActionJoin extends Action {
+    public readonly name: string = 'Join';
+
+    constructor(private readonly separator: string = '\n') {
+        super();
+    }
+
+    run(input: ActionResult): ActionResult {
+        const lines = input.text.split(/\n/);
+        input.text = lines.join(this.separator);
+        return input;
+    }
+}

--- a/src/textwandler/wandler-pipeline/actions/index.ts
+++ b/src/textwandler/wandler-pipeline/actions/index.ts
@@ -1,5 +1,6 @@
 export { Action } from './action';
 export { ActionFilterLine } from './action-filter-line';
+export { ActionJoin } from './action-join';
 export { ActionJsonParse } from './action-json-parse';
 export { ActionJsonStringify } from './action-json-stringify';
 export { ActionReduce } from './action-reduce';

--- a/src/textwandler/wandler-pipeline/pipeline.ts
+++ b/src/textwandler/wandler-pipeline/pipeline.ts
@@ -1,6 +1,7 @@
 import { Action, ActionResult } from './actions/action';
 import { ActionTransformLine } from './actions/action-transform-line';
 import { ActionFilterLine } from './actions/action-filter-line';
+import { ActionJoin } from './actions/action-join';
 import { ActionSetValue } from './actions/action-set-value';
 import { ActionReduce } from './actions/action-reduce';
 import { ActionJsonStringify } from './actions/action-json-stringify';
@@ -90,6 +91,9 @@ export class WandlerPipeline {
             ) => {
                 this.addAction(new ActionJsonParse(transformJsonFunction));
                 this.addAction(new ActionJsonStringify(indentation));
+            },
+            join: (separator?: string) => {
+                this.addAction(new ActionJoin(separator));
             },
             jsonStringify: (indentation?: number) =>
                 this.addAction(new ActionJsonStringify(indentation)),

--- a/test/e2e/actions.e2e.test.ts
+++ b/test/e2e/actions.e2e.test.ts
@@ -91,3 +91,30 @@ test('Action: unique', async ({ page }) => {
         `x\nz\n111\n222`
     );
 });
+
+test('Action: join - comma separator', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `join(', ');`,
+        `apple\nbanana\ncherry\ndate`,
+        `apple, banana, cherry, date`
+    );
+});
+
+test('Action: join - pipe separator', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `join(' | ');`,
+        `first\nsecond\nthird`,
+        `first | second | third`
+    );
+});
+
+test('Action: join - space separator', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `join(' ');`,
+        `one\ntwo\nthree\nfour`,
+        `one two three four`
+    );
+});

--- a/test/textwandler/wandler-pipeline/pipeline.test.ts
+++ b/test/textwandler/wandler-pipeline/pipeline.test.ts
@@ -4,6 +4,7 @@ import {
     ActionReduce,
     ActionSetValue,
     ActionFilterLine,
+    ActionJoin,
     ActionJsonStringify,
     ActionJsonParse,
     WandlerPipeline,
@@ -204,6 +205,34 @@ describe('Test of WandlerPipeline', () => {
           c
           1
           2"
+        `);
+    });
+
+    it('should execute join action with comma separator', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionJoin(', '));
+
+        const result = pipeline.run('apple\nbanana\ncherry\ndate');
+        expect(result).toMatchInlineSnapshot(`"apple, banana, cherry, date"`);
+    });
+
+    it('should execute join action with pipe separator', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionJoin(' | '));
+
+        const result = pipeline.run('first\nsecond\nthird');
+        expect(result).toMatchInlineSnapshot(`"first | second | third"`);
+    });
+
+    it('should execute join action with default separator', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionJoin());
+
+        const result = pipeline.run('line1\nline2\nline3');
+        expect(result).toMatchInlineSnapshot(`
+          "line1
+          line2
+          line3"
         `);
     });
 });


### PR DESCRIPTION
Implement join action for combining lines with separators.

- Created ActionJoin class with configurable separator
- Added join() method to pipeline context
- Added unit tests and e2e tests for various join scenarios
- Updated TypeScript definitions and README
- Default separator maintains newlines, custom separators enable CSV, pipe-delimited formats