### PR TITLE
fix: add trim action

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ function transformLine(callback: (lineContent: string, lineNumber: number) => st
 transformLine((lineContent, lineNumber) => `${lineNumber} ${lineContent}`);
 ```
 
+### trim
+
+Removes whitespace from the beginning and/or end of each line. Includes convenience methods for specific trimming.
+
+```js
+function trim(mode?: 'both' | 'start' | 'end'): void
+function trimStart(): void
+function trimEnd(): void
+```
+
+```js
+// Remove whitespace from both sides (default)
+trim();
+trim('both');
+
+// Remove whitespace from start only
+trim('start');
+trimStart();
+
+// Remove whitespace from end only
+trim('end');
+trimEnd();
+```
+
 ### reduce
 
 Iterates over every line and gives it to the provided callback. In the end the result of the last callback execution is stringified and written to the output.

--- a/src/monaco-extra-libs/action-functions.d.ts
+++ b/src/monaco-extra-libs/action-functions.d.ts
@@ -106,6 +106,25 @@ declare function CallbackTransformLine(
 ): string;
 
 /**
+ * Removes whitespace from the beginning and/or end of each line
+ * @param {'both' | 'start' | 'end'} [mode='both'] Which whitespace to trim
+ * @returns void
+ */
+declare function trim(mode?: 'both' | 'start' | 'end'): void;
+
+/**
+ * Removes whitespace from the beginning of each line
+ * @returns void
+ */
+declare function trimStart(): void;
+
+/**
+ * Removes whitespace from the end of each line
+ * @returns void
+ */
+declare function trimEnd(): void;
+
+/**
  * Filters all lines and leaves only unique ones as a result for the next stage
  * @returns void
  */
@@ -118,6 +137,9 @@ declare interface TextwandlerFunctions {
     reduce: typeof reduce;
     setValue: typeof setValue;
     transformLine: typeof transformLine;
+    trim: typeof trim;
+    trimStart: typeof trimStart;
+    trimEnd: typeof trimEnd;
     unique: typeof unique;
 }
 

--- a/src/textwandler/wandler-pipeline/actions/action-trim.ts
+++ b/src/textwandler/wandler-pipeline/actions/action-trim.ts
@@ -1,0 +1,27 @@
+import { Action, ActionResult } from './action';
+
+export class ActionTrim extends Action {
+    public readonly name: string = 'Trim';
+
+    constructor(private readonly mode: 'both' | 'start' | 'end' = 'both') {
+        super();
+    }
+
+    run(input: ActionResult): ActionResult {
+        const lines = input.text.split(/\n/);
+        const trimmedLines = lines.map(line => {
+            switch (this.mode) {
+                case 'start':
+                    return line.trimStart();
+                case 'end':
+                    return line.trimEnd();
+                case 'both':
+                default:
+                    return line.trim();
+            }
+        });
+        
+        input.text = trimmedLines.join('\n');
+        return input;
+    }
+}

--- a/src/textwandler/wandler-pipeline/actions/index.ts
+++ b/src/textwandler/wandler-pipeline/actions/index.ts
@@ -5,4 +5,5 @@ export { ActionJsonStringify } from './action-json-stringify';
 export { ActionReduce } from './action-reduce';
 export { ActionSetValue } from './action-set-value';
 export { ActionTransformLine } from './action-transform-line';
+export { ActionTrim } from './action-trim';
 export { ActionUnique } from './action-unique';

--- a/src/textwandler/wandler-pipeline/pipeline.ts
+++ b/src/textwandler/wandler-pipeline/pipeline.ts
@@ -5,6 +5,7 @@ import { ActionSetValue } from './actions/action-set-value';
 import { ActionReduce } from './actions/action-reduce';
 import { ActionJsonStringify } from './actions/action-json-stringify';
 import { ActionJsonParse } from './actions/action-json-parse';
+import { ActionTrim } from './actions/action-trim';
 import { ActionUnique } from './actions/action-unique';
 
 export type ActionRunStep = {
@@ -111,6 +112,15 @@ export class WandlerPipeline {
                 lineMapper: (line: string, lineNumber: number) => string
             ) => {
                 this.addAction(new ActionTransformLine(lineMapper));
+            },
+            trim: (mode?: 'both' | 'start' | 'end') => {
+                this.addAction(new ActionTrim(mode));
+            },
+            trimStart: () => {
+                this.addAction(new ActionTrim('start'));
+            },
+            trimEnd: () => {
+                this.addAction(new ActionTrim('end'));
             },
             unique: () => {
                 this.addAction(new ActionUnique());

--- a/test/e2e/actions.e2e.test.ts
+++ b/test/e2e/actions.e2e.test.ts
@@ -91,3 +91,30 @@ test('Action: unique', async ({ page }) => {
         `x\nz\n111\n222`
     );
 });
+
+test('Action: trim - both sides', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `trim();`,
+        `  line1  \n\t\tline2\t\t\n   line3   `,
+        `line1\nline2\nline3`
+    );
+});
+
+test('Action: trimStart - left side only', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `trimStart();`,
+        `  line1  \n\t\tline2\t\t\n   line3   `,
+        `line1  \nline2\t\t\nline3   `
+    );
+});
+
+test('Action: trimEnd - right side only', async ({ page }) => {
+    await testEditorContent(
+        page,
+        `trimEnd();`,
+        `  line1  \n\t\tline2\t\t\n   line3   `,
+        `  line1\n\t\tline2\n   line3`
+    );
+});

--- a/test/textwandler/wandler-pipeline/pipeline.test.ts
+++ b/test/textwandler/wandler-pipeline/pipeline.test.ts
@@ -7,6 +7,7 @@ import {
     ActionJsonStringify,
     ActionJsonParse,
     WandlerPipeline,
+    ActionTrim,
     ActionUnique
 } from '../../../src/textwandler';
 
@@ -204,6 +205,42 @@ describe('Test of WandlerPipeline', () => {
           c
           1
           2"
+        `);
+    });
+
+    it('should execute trim action with both sides', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionTrim('both'));
+
+        const result = pipeline.run('  line1  \n\t\tline2\t\t\n   line3   ');
+        expect(result).toMatchInlineSnapshot(`
+          "line1
+          line2
+          line3"
+        `);
+    });
+
+    it('should execute trim action with start only', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionTrim('start'));
+
+        const result = pipeline.run('  line1  \n\t\tline2\t\t\n   line3   ');
+        expect(result).toMatchInlineSnapshot(`
+          "line1  
+          line2\t\t
+          line3   "
+        `);
+    });
+
+    it('should execute trim action with end only', () => {
+        const pipeline = new WandlerPipeline();
+        pipeline.addAction(new ActionTrim('end'));
+
+        const result = pipeline.run('  line1  \n\t\tline2\t\t\n   line3   ');
+        expect(result).toMatchInlineSnapshot(`
+          "  line1
+          \t\tline2
+             line3"
         `);
     });
 });


### PR DESCRIPTION
Implement trim action for removing whitespace from lines.

- Created ActionTrim class with configurable trimming modes
- Added trim(), trimStart(), and trimEnd() methods to pipeline context
- Added unit tests and e2e tests for all trim modes
- Updated TypeScript definitions and README
- Supports trimming both sides, start only, or end only